### PR TITLE
Remove redundant PcdSystemMemoryBase

### DIFF
--- a/Silicon/QC/Sm8150/QcomPkg/QcomPkg.dsc.inc
+++ b/Silicon/QC/Sm8150/QcomPkg/QcomPkg.dsc.inc
@@ -27,7 +27,6 @@
   gSurfaceDuoFamilyPkgTokenSpaceGuid.PcdSmbiosProcessorModel|"Snapdragon (TM) 855 @ 2.84 GHz"
   gSurfaceDuoFamilyPkgTokenSpaceGuid.PcdSmbiosProcessorRetailModel|"SM8150"
 
-  gArmTokenSpaceGuid.PcdSystemMemoryBase|0x80000000         # 2GB Base
   gArmPlatformTokenSpaceGuid.PcdCoreCount|8
   gArmPlatformTokenSpaceGuid.PcdClusterCount|3
 

--- a/Silicon/QC/Sm8350/QcomPkg/QcomPkg.dsc.inc
+++ b/Silicon/QC/Sm8350/QcomPkg/QcomPkg.dsc.inc
@@ -27,7 +27,6 @@
   gSurfaceDuoFamilyPkgTokenSpaceGuid.PcdSmbiosProcessorModel|"Snapdragon (TM) 888 @ 2.84 GHz"
   gSurfaceDuoFamilyPkgTokenSpaceGuid.PcdSmbiosProcessorRetailModel|"SM8350"
 
-  gArmTokenSpaceGuid.PcdSystemMemoryBase|0x80000000         # 2GB Base
   gArmPlatformTokenSpaceGuid.PcdCoreCount|8
   gArmPlatformTokenSpaceGuid.PcdClusterCount|3
 


### PR DESCRIPTION
Not sure if this was made on purpose, but technically this is a typo since both PcdSystemMemoryBase are same and second one just overwrites first one